### PR TITLE
Use same base digit for fromInt and fromString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ elm-stuff/
 repl-temp-*
 # elm-make Test.elm generated files
 index.html
+# IntelliJ project files
+.idea/

--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -168,6 +168,11 @@ maxDigitValue =
     -1 + 10 ^ maxDigitMagnitude
 
 
+baseDigit : Int
+baseDigit =
+    maxDigitValue + 1
+
+
 maxDigitMagnitude : Int
 maxDigitMagnitude =
     7
@@ -593,7 +598,7 @@ maxDigitBits =
 
 padDigits : Int -> BigInt
 padDigits n =
-    repeatedly (mul (fromInt maxDigitValue)) one n
+    repeatedly (mul (fromInt baseDigit)) one n
 
 
 repeatedly : (a -> a) -> a -> Int -> a
@@ -666,10 +671,10 @@ normaliseDigitList carry xs =
 normaliseDigit : Int -> ( Int, Int )
 normaliseDigit x =
     if x < 0 then
-        normaliseDigit (x + maxDigitValue)
+        normaliseDigit (x + baseDigit)
             |> Tuple.mapFirst ((+) -1)
     else
-        ( x // maxDigitValue, rem x maxDigitValue )
+        ( x // baseDigit, rem x baseDigit )
 
 
 dropZeroes : List Int -> List Int

--- a/tests/BigIntTests.elm
+++ b/tests/BigIntTests.elm
@@ -43,6 +43,42 @@ smallInt =
     conditional { retries = 16, fallback = always 0, condition = (>=) 1000000 << Basics.abs } int
 
 
+fromTests : Test
+fromTests =
+    describe "from"
+        [ test "fromString 9999999 = fromInt 9999999" <|
+            \_ ->
+                let
+                    fromString =
+                        BigInt.fromString "9999999"
+
+                    fromInt =
+                        BigInt.fromInt 9999999
+                in
+                    Expect.equal fromString (Just fromInt)
+        , test "fromString 10000000 = fromInt 10000000" <|
+            \_ ->
+                let
+                    fromString =
+                        BigInt.fromString "10000000"
+
+                    fromInt =
+                        BigInt.fromInt 10000000
+                in
+                    Expect.equal fromString (Just fromInt)
+        , test "fromString 10000001 = fromInt 10000001" <|
+            \_ ->
+                let
+                    fromString =
+                        BigInt.fromString "10000001"
+
+                    fromInt =
+                        BigInt.fromInt 10000001
+                in
+                    Expect.equal fromString (Just fromInt)
+        ]
+
+
 addTests : Test
 addTests =
     describe "addition"


### PR DESCRIPTION
`fromInt` was using 9999999 as its radix and `fromString` was using 10000000.

This commit changes `fromInt` to use the same radix as `fromString`.